### PR TITLE
accept and set signupSource on social signup

### DIFF
--- a/lib/kaiseki.js
+++ b/lib/kaiseki.js
@@ -366,13 +366,16 @@ Kaiseki.prototype = {
   },
 
   _socialLogin: function(authData, signupSource, callback) {
+    var params = {
+      authData: authData
+    };
+    if (signupSource) {
+      params.signupSource = signupSource;
+    }
     this._jsonRequest({
       method: 'POST',
       url: '/1/users',
-      params: {
-        authData: authData,
-        signupSource: signupSource
-      },
+      params: params,
       callback: callback
     });
   },


### PR DESCRIPTION
Set `signupSource` property on the user when creating them.  Updates `loginFacebookUser` and `loginTwitterUser` to optionally accept a `signupSource` parameter.

https://haikudeck.atlassian.net/browse/PTS-74

@collinwat 
